### PR TITLE
Fix Mod `vanillaexcavators` (1.1.0) uses 'requires' key in fabric.mod.json, which is not supported - use 'depends'

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   "mixins": [
     "vanillaexcavators.mixin.json"
   ],
-  "requires": {
+  "depends": {
     "fabricloader": "=>0.4.0",
     "fabric": "*"
   }


### PR DESCRIPTION
```
[10:22:50] [main/WARN]: Mod `vanillaexcavators` (1.1.0) uses 'requires' key in fabric.mod.json, which is not supported - use 'depends'
```